### PR TITLE
fix(join-location): use AsyncPlayerSpawnLocationEvent on Paper to sup…

### DIFF
--- a/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/WorldGuardExtraFlagsPlusPlugin.java
+++ b/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/WorldGuardExtraFlagsPlusPlugin.java
@@ -279,12 +279,21 @@ public class WorldGuardExtraFlagsPlusPlugin extends JavaPlugin
 		// Conditionally register JoinLocationListener only if join-location flag is enabled
 		if (Config.isFlagEnabled("join-location"))
 		{
-			this.getServer().getPluginManager().registerEvents(new JoinLocationListener(this.worldGuardPlugin, this.regionContainer), this);
-			this.sendJoinLocationDeprecationWarning();
+			if (isPaperServer())
+			{
+				// On Paper: use AsyncPlayerSpawnLocationEvent (non-deprecated)
+				this.getServer().getPluginManager().registerEvents(new AsyncJoinLocationListener(this.regionContainer), this);
+			}
+			else
+			{
+				// On Spigot: fall back to deprecated PlayerSpawnLocationEvent
+				this.getServer().getPluginManager().registerEvents(new JoinLocationListener(this.worldGuardPlugin, this.regionContainer), this);
+				this.sendJoinLocationDeprecationWarning();
+			}
 		} else {
-      this.getLogger().info(" ");
+			this.getLogger().info(" ");
 			this.getLogger().info("[Join Location Flag] Disabled in config-wgefp.yml it will not load the flag");
-      this.getLogger().info(" ");
+			this.getLogger().info(" ");
 		}
 		// Register listeners based on configuration
 		if (Config.isFlagEnabled("allow-block-place") || Config.isFlagEnabled("deny-block-place") ||
@@ -351,14 +360,27 @@ public class WorldGuardExtraFlagsPlusPlugin extends JavaPlugin
 		this.getCommand("wgefp").setTabCompleter(new dev.tins.worldguardextraflagsplus.commands.ReloadCommand(this));
 	}
 
-  private void sendJoinLocationDeprecationWarning()
-  {
-    this.getLogger().info(" >> >> ");
-    this.getLogger().info(" >> >> If you are not using \"join-location\" flag, you can disable it in the \"config-wgefp.yml\" ");
-    this.getLogger().info(" >> >> This will avoid the deprecation warning on server load");
-    this.getLogger().info(" >> >> Otherwise, the plugin will work correctly, deprecation warning will not broke working of it.");
+	private static boolean isPaperServer()
+	{
+		try
+		{
+			Class.forName("io.papermc.paper.event.player.AsyncPlayerSpawnLocationEvent");
+			return true;
+		}
+		catch (ClassNotFoundException e)
+		{
+			return false;
+		}
+	}
+
+	private void sendJoinLocationDeprecationWarning()
+	{
 		this.getLogger().info(" >> >> ");
-  }
+		this.getLogger().info(" >> >> If you are not using \"join-location\" flag, you can disable it in the \"config-wgefp.yml\" ");
+		this.getLogger().info(" >> >> This will avoid the deprecation warning on server load");
+		this.getLogger().info(" >> >> Otherwise, the plugin will work correctly, deprecation warning will not broke working of it.");
+		this.getLogger().info(" >> >> ");
+	}
 
 	public void doUnloadChunkFlagCheck(org.bukkit.World world)
 	{

--- a/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/listeners/AsyncJoinLocationListener.java
+++ b/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/listeners/AsyncJoinLocationListener.java
@@ -1,0 +1,39 @@
+package dev.tins.worldguardextraflagsplus.listeners;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
+import io.papermc.paper.event.player.AsyncPlayerSpawnLocationEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Paper-specific listener for join-location flag functionality.
+ * Uses AsyncPlayerSpawnLocationEvent instead of the deprecated PlayerSpawnLocationEvent.
+ * Only registered on Paper servers when join-location.enabled is true in config.
+ */
+@RequiredArgsConstructor
+public class AsyncJoinLocationListener implements Listener
+{
+	private final RegionContainer regionContainer;
+
+	@EventHandler(priority = EventPriority.HIGHEST)
+	public void onAsyncPlayerSpawnLocation(AsyncPlayerSpawnLocationEvent event)
+	{
+		// null is passed as RegionAssociable - LocationFlag does not depend on region membership,
+		// so the flag value is returned regardless of who the player is.
+		Location location = this.regionContainer.createQuery().queryValue(
+				BukkitAdapter.adapt(event.getSpawnLocation()),
+				null,
+				dev.tins.worldguardextraflagsplus.flags.Flags.JOIN_LOCATION
+		);
+
+		if (location != null)
+		{
+			event.setSpawnLocation(BukkitAdapter.adapt(location));
+		}
+	}
+}


### PR DESCRIPTION
…press deprecation warning

On Paper servers, register AsyncJoinLocationListener which handles AsyncPlayerSpawnLocationEvent instead of the deprecated PlayerSpawnLocationEvent. Spigot servers fall back to the old behavior.