### PR TITLE
feat: add lightning-damage region flag

### DIFF
--- a/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/Config.java
+++ b/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/Config.java
@@ -234,6 +234,7 @@ public class Config
 			case "disable-collision": return flags.isDisableCollision();
 			case "chambered-enderpearl": return flags.isChamberedEnderPearl();
 			case "hide-players": return flags.isHidePlayers();
+			case "lightning-damage": return flags.isLightningDamage();
 
 			default: return true; // Default to enabled for unknown flags
 		}

--- a/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/WorldGuardExtraFlagsPlusPlugin.java
+++ b/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/WorldGuardExtraFlagsPlusPlugin.java
@@ -142,6 +142,7 @@ public class WorldGuardExtraFlagsPlusPlugin extends JavaPlugin
 			if (Config.isFlagEnabled("disable-collision")) flagRegistry.register(Flags.DISABLE_COLLISION);
 			if (Config.isFlagEnabled("chambered-enderpearl")) flagRegistry.register(Flags.CHAMBERED_ENDERPEARL);
 			if (Config.isFlagEnabled("hide-players")) flagRegistry.register(Flags.HIDE_PLAYERS);
+			if (Config.isFlagEnabled("lightning-damage")) flagRegistry.register(Flags.LIGHTNING_DAMAGE);
 		}
 		catch (Exception e)
 		{
@@ -234,6 +235,13 @@ public class WorldGuardExtraFlagsPlusPlugin extends JavaPlugin
 		if (Config.isFlagEnabled("hide-players"))
 		{
 			this.sessionManager.registerHandler(HidePlayersFlagHandler.FACTORY, null);
+		}
+
+		if (Config.isFlagEnabled("lightning-damage"))
+		{
+			this.getServer().getPluginManager().registerEvents(
+					new dev.tins.worldguardextraflagsplus.listeners.LightningDamageListener(
+							this.worldGuardPlugin, this.regionContainer, this.sessionManager), this);
 		}
 
 		// Register PlayerListener (contains multiple event handlers)

--- a/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/config/PluginConfig.java
+++ b/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/config/PluginConfig.java
@@ -282,6 +282,17 @@ public final class PluginConfig {
 			"Default: false — enable here and set hide-players: true on regions to use."
 		})
 		private boolean hidePlayers = false;
+
+		@Comment({
+			"WEATHER & ENVIRONMENTAL DAMAGE",
+			"------------------------------",
+			"lightning-damage flag",
+			"When set to deny on a region, players won't take damage from lightning strikes",
+			"but the visual effect is still shown. Useful for PvP arenas.",
+			"Usage: /rg flag <region> lightning-damage deny",
+			"Default: true"
+		})
+		private boolean lightningDamage = true;
 	}
 }
 

--- a/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/listeners/LightningDamageListener.java
+++ b/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/listeners/LightningDamageListener.java
@@ -1,0 +1,77 @@
+package dev.tins.worldguardextraflagsplus.listeners;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
+import com.sk89q.worldguard.protection.flags.StateFlag.State;
+import com.sk89q.worldguard.session.SessionManager;
+import dev.tins.worldguardextraflagsplus.flags.Flags;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+
+/**
+ * Handles the {@code lightning-damage} flag.
+ *
+ * <p>When set to {@code deny} in a region, lightning strikes will still appear
+ * visually (the strike effect plays) but players inside the region will not
+ * take any damage from lightning. Useful for PvP arenas that want the visual
+ * effect without the environmental hazard.</p>
+ *
+ * <p>Usage: {@code /rg flag <region> lightning-damage deny}</p>
+ */
+public class LightningDamageListener implements Listener
+{
+    private final WorldGuardPlugin worldGuardPlugin;
+    private final RegionContainer regionContainer;
+    private final SessionManager sessionManager;
+
+    public LightningDamageListener(WorldGuardPlugin worldGuardPlugin,
+                                   RegionContainer regionContainer,
+                                   SessionManager sessionManager)
+    {
+        this.worldGuardPlugin = worldGuardPlugin;
+        this.regionContainer = regionContainer;
+        this.sessionManager = sessionManager;
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    public void onLightningDamage(EntityDamageEvent event)
+    {
+        // Only intercept lightning damage
+        if (event.getCause() != DamageCause.LIGHTNING)
+        {
+            return;
+        }
+
+        // Only protect players
+        if (!(event.getEntity() instanceof Player player))
+        {
+            return;
+        }
+
+        LocalPlayer localPlayer = this.worldGuardPlugin.wrapPlayer(player);
+
+        // Bypass for players with WorldGuard bypass permission
+        if (this.sessionManager.hasBypass(localPlayer, localPlayer.getWorld()))
+        {
+            return;
+        }
+
+        // Check lightning-damage flag at the player's location
+        State state = this.regionContainer.createQuery().queryState(
+                BukkitAdapter.adapt(player.getLocation()),
+                localPlayer,
+                Flags.LIGHTNING_DAMAGE);
+
+        // Cancel damage if the flag is explicitly denied
+        if (state == State.DENY)
+        {
+            event.setCancelled(true);
+        }
+    }
+}

--- a/WG/src/main/java/dev/tins/worldguardextraflagsplus/flags/Flags.java
+++ b/WG/src/main/java/dev/tins/worldguardextraflagsplus/flags/Flags.java
@@ -90,6 +90,13 @@ public final class Flags
 	public final static Flag<String> PLAYER_COUNT_LIMIT = new IntegerFlag("player-count-limit");
 
 	public final static StateFlag CHAMBERED_ENDERPEARL = new StateFlag("chambered-enderpearl", true);
+
+	/**
+	 * Controls whether lightning strikes deal damage to players in this region.
+	 * Default is allow (true) — lightning deals damage normally.
+	 * Set to deny to show the lightning visually but cancel the damage to players.
+	 */
+	public final static StateFlag LIGHTNING_DAMAGE = new StateFlag("lightning-damage", true);
 }
 
 


### PR DESCRIPTION
Add new StateFlag 'lightning-damage' that allows lightning strikes to appear visually in a region while preventing damage to players.

Useful for PvP arenas where the lightning effect is desired but environmental damage should be blocked.

Usage: /rg flag <region> lightning-damage deny

Changes:
- Flags.java: register LIGHTNING_DAMAGE StateFlag (default: allow)
- LightningDamageListener.java: new listener for EntityDamageEvent with DamageCause.LIGHTNING, cancels damage when flag is DENY
- WorldGuardExtraFlagsPlusPlugin.java: register flag and listener
- PluginConfig.java: add lightningDamage toggle to AllFlagsControl
- Config.java: add 'lightning-damage' case to isFlagEnabled()