### PR TITLE
feat: add entry-permission and entry-deny-permission region flag

### DIFF
--- a/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/Config.java
+++ b/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/Config.java
@@ -228,6 +228,8 @@ public class Config
 			// Entry Control
 			case "entry-min-level": return flags.isEntryMinLevel();
 			case "entry-max-level": return flags.isEntryMaxLevel();
+			case "entry-permission": return flags.isEntryPermission();
+			case "entry-deny-permission": return flags.isEntryDenyPermission();
 			case "player-count-limit": return flags.isPlayerCountLimit();
 
 			// Special Features

--- a/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/WorldGuardExtraFlagsPlusPlugin.java
+++ b/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/WorldGuardExtraFlagsPlusPlugin.java
@@ -31,7 +31,7 @@ import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.protection.flags.Flag;
 
 import lombok.Getter;
-
+import dev.tins.worldguardextraflagsplus.api.FlagDescriptions.FlagMeta;
 import dev.tins.worldguardextraflagsplus.disablecompletely.DisableCompletelyQuery;
 import dev.tins.worldguardextraflagsplus.flags.Flags;
 import dev.tins.worldguardextraflagsplus.protocollib.ProtocolLibHelper;
@@ -134,6 +134,8 @@ public class WorldGuardExtraFlagsPlusPlugin extends JavaPlugin
 			if (Config.isFlagEnabled("permit-workbenches")) flagRegistry.register(Flags.PERMIT_WORKBENCHES);
 			if (Config.isFlagEnabled("entry-min-level")) flagRegistry.register(Flags.ENTRY_MIN_LEVEL);
 			if (Config.isFlagEnabled("entry-max-level")) flagRegistry.register(Flags.ENTRY_MAX_LEVEL);
+			if (Config.isFlagEnabled("entry-permission")) flagRegistry.register(Flags.ENTRY_PERMISSION);
+			if (Config.isFlagEnabled("entry-deny-permission")) flagRegistry.register(Flags.ENTRY_DENY_PERMISSION);
 			if (Config.isFlagEnabled("player-count-limit")) flagRegistry.register(Flags.PLAYER_COUNT_LIMIT);
 			if (Config.isFlagEnabled("villager-trade")) flagRegistry.register(Flags.VILLAGER_TRADE);
 			if (Config.isFlagEnabled("inventory-craft")) flagRegistry.register(Flags.INVENTORY_CRAFT);
@@ -219,6 +221,7 @@ public class WorldGuardExtraFlagsPlusPlugin extends JavaPlugin
 		if (Config.isFlagEnabled("console-command-on-entry")) this.sessionManager.registerHandler(ConsoleCommandOnEntryFlagHandler.FACTORY(), null);
 		if (Config.isFlagEnabled("console-command-on-exit")) this.sessionManager.registerHandler(ConsoleCommandOnExitFlagHandler.FACTORY(), null);
 			if (Config.isFlagEnabled("entry-min-level") || Config.isFlagEnabled("entry-max-level")) this.sessionManager.registerHandler(EntryLevelFlagHandler.FACTORY(plugin), null);
+			if (Config.isFlagEnabled("entry-permission") || Config.isFlagEnabled("entry-deny-permission")) this.sessionManager.registerHandler(EntryPermissionFlagHandler.FACTORY(plugin), null);
 			if (Config.isFlagEnabled("player-count-limit")) this.sessionManager.registerHandler(PlayerCountLimitFlagHandler.FACTORY(plugin), null);
 		
 		// Initialize collision handler when disable-collision flag is enabled

--- a/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/api/FlagDescriptions.java
+++ b/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/api/FlagDescriptions.java
@@ -220,6 +220,16 @@ public final class FlagDescriptions
 				"Sets the maximum player XP level (or PlaceholderAPI integer value) allowed to enter the region.",
 				"number or PlaceholderAPI placeholder",
 				"/rg flag <region> entry-max-level 50"));
+		
+		ALL.put("entry-permission", new FlagMeta(
+				"Sets the permission required to enter the region. Takes priority over entry-deny-permission.",
+				"myPlugin.myPermission.1",
+				"/rg flag <region> entry-permission myPlugin.myPermission.1"));
+
+		ALL.put("entry-deny-permission", new FlagMeta(
+				"Sets the permission that denies entry from the region. If both flags are defined, entry-permission has higher priority.",
+				"myPlugin.myPermission.1",
+				"/rg flag <region> entry-deny-permission myPlugin.myPermission.1"));
 
 		ALL.put("player-count-limit", new FlagMeta(
 				"Limits the maximum number of players that can be inside the region at the same time.",

--- a/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/config/PluginConfig.java
+++ b/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/config/PluginConfig.java
@@ -263,6 +263,21 @@ public final class PluginConfig {
 		})
 		private boolean entryMinLevel = true;
 		private boolean entryMaxLevel = true;
+		@Comment({
+			"entry-permission flag",
+			"Allows players with the specified permission to enter the region.",
+			"Usage: /rg flag <region> entry-permission myPlugin.permission",
+			"Default: true"
+		})
+		private boolean entryPermission = true;
+		@Comment({
+			"entry-deny-permission flag",
+			"Denies entry to players with the specified permission.",
+			"If a player has both entry-permission and entry-deny-permission, entry-permission takes priority.",
+			"Usage: /rg flag <region> entry-deny-permission myPlugin.deny",
+			"Default: true"
+		})
+		private boolean entryDenyPermission = true;
 		private boolean playerCountLimit = true;
 
 		@Comment({

--- a/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/config/PluginMessages.java
+++ b/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/config/PluginMessages.java
@@ -58,6 +58,12 @@ public final class PluginMessages {
 	@Comment("Entry level flags messages")
 	private String entryMaxLevelDenied = "&cYour level (&7{current}&c) is so high to enter this area. &7Max: &8{required}";
 	
+	@Comment("Entry permission flags messages")
+	private String entryPermissionDenied = "&cHey! &7You do not have the required permission {permission} to enter this area.";
+	
+	@Comment("Entry permission flags messages")
+	private String entryDenyPermissionDenied = "&cHey! &7You may not enter this area with the permission {permission}.";
+
 	@Comment("Disable completely flag message")
 	private String disableCompletelyBlocked = "&cHey! &7You can not use {item} in here!";
 	

--- a/WG/src/main/java/dev/tins/worldguardextraflagsplus/flags/Flags.java
+++ b/WG/src/main/java/dev/tins/worldguardextraflagsplus/flags/Flags.java
@@ -1,6 +1,9 @@
 package dev.tins.worldguardextraflagsplus.flags;
 
 import dev.tins.worldguardextraflagsplus.flags.helpers.*;
+
+import javax.print.DocFlavor.STRING;
+
 import org.bukkit.Material;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -87,6 +90,10 @@ public final class Flags
 
 	public final static Flag<String> ENTRY_MIN_LEVEL = new PlaceholderLevelFlag("entry-min-level");
 	public final static Flag<String> ENTRY_MAX_LEVEL = new PlaceholderLevelFlag("entry-max-level");
+
+	public final static Flag<String> ENTRY_PERMISSION = new PermissionStateFlag("entry-permission");
+	public final static Flag<String> ENTRY_DENY_PERMISSION = new PermissionStateFlag("entry-deny-permission");
+
 	public final static Flag<String> PLAYER_COUNT_LIMIT = new IntegerFlag("player-count-limit");
 
 	public final static StateFlag CHAMBERED_ENDERPEARL = new StateFlag("chambered-enderpearl", true);

--- a/WG/src/main/java/dev/tins/worldguardextraflagsplus/flags/helpers/PermissionStateFlag.java
+++ b/WG/src/main/java/dev/tins/worldguardextraflagsplus/flags/helpers/PermissionStateFlag.java
@@ -1,0 +1,50 @@
+package dev.tins.worldguardextraflagsplus.flags.helpers;
+
+import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.FlagContext;
+import com.sk89q.worldguard.protection.flags.InvalidFlagFormat;
+
+/**
+ * Custom flag type for permission-based entry control.
+ * Accepts permission strings like "myPlugin.permission.1" or "*" for all permissions.
+ */
+public class PermissionStateFlag extends Flag<String>
+{
+	public PermissionStateFlag(String name)
+	{
+		super(name);
+	}
+
+	@Override
+	public String parseInput(FlagContext context) throws InvalidFlagFormat
+	{
+		String input = context.getUserInput().trim();
+		
+		if (input.isEmpty())
+		{
+			throw new InvalidFlagFormat("Permission cannot be empty. Format: permission.node (e.g., myPlugin.enter.premium)");
+		}
+		
+		// Validate basic permission format - alphanumeric, dots, hyphens, underscores, and wildcards
+		if (!input.matches("^[a-zA-Z0-9._*-]+$"))
+		{
+			throw new InvalidFlagFormat("Invalid permission format: '" + input + "'. Use alphanumeric characters, dots, hyphens, and underscores. Wildcards (*) are allowed.");
+		}
+		
+		return input;
+	}
+
+	@Override
+	public Object marshal(String o)
+	{
+		return o;
+	}
+
+	@Override
+    public String unmarshal(Object o) {
+        if (o == null) {
+            return null;
+        }
+        return o.toString();
+    }
+}

--- a/WG/src/main/java/dev/tins/worldguardextraflagsplus/wg/handlers/EntryPermissionFlagHandler.java
+++ b/WG/src/main/java/dev/tins/worldguardextraflagsplus/wg/handlers/EntryPermissionFlagHandler.java
@@ -1,0 +1,177 @@
+package dev.tins.worldguardextraflagsplus.wg.handlers;
+
+import com.sk89q.worldedit.bukkit.BukkitPlayer;
+import com.sk89q.worldedit.util.Location;
+import com.sk89q.worldedit.world.World;
+import com.sk89q.worldguard.LocalPlayer;
+import com.sk89q.worldguard.session.handler.Handler;
+import com.sk89q.worldguard.session.Session;
+
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import com.sk89q.worldguard.session.MoveType;
+
+import dev.tins.worldguardextraflagsplus.flags.Flags;
+import dev.tins.worldguardextraflagsplus.wg.WorldGuardUtils;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Set;
+
+/**
+ * Handler for entry-permission and entry-deny-permission flags.
+ * 
+ * entry-permission: Allows only players with the given permission to enter
+ * entry-deny-permission: Denies entry to players with the given permission
+ * 
+ * If player has both permissions, entry-permission takes priority.
+ */
+public class EntryPermissionFlagHandler extends Handler
+{
+	public static final Factory FACTORY(Plugin plugin)
+	{
+		return new Factory(plugin);
+	}
+
+	public static class Factory extends Handler.Factory<EntryPermissionFlagHandler>
+	{
+		private final Plugin plugin;
+
+		public Factory(Plugin plugin)
+		{
+			this.plugin = plugin;
+		}
+
+		@Override
+		public EntryPermissionFlagHandler create(Session session)
+		{
+			return new EntryPermissionFlagHandler(this.plugin, session);
+		}
+	}
+
+	private final Plugin plugin;
+
+	protected EntryPermissionFlagHandler(Plugin plugin, Session session)
+	{
+		super(session);
+		this.plugin = plugin;
+	}
+
+	@Override
+	public boolean onCrossBoundary(LocalPlayer player, Location from, Location to, ApplicableRegionSet toSet, Set<ProtectedRegion> entered, Set<ProtectedRegion> exited, MoveType moveType)
+	{
+		// Check if player has bypass
+		if (this.getSession().getManager().hasBypass(player, (World) to.getExtent()))
+		{
+			return true; // Allow entry if player has bypass
+		}
+
+		// Get the Bukkit player for permission checking
+		Player bukkitPlayer = ((BukkitPlayer) player).getPlayer();
+		if (bukkitPlayer == null || !bukkitPlayer.isOnline())
+		{
+			return true; // Allow if player is offline or not found
+		}
+
+		// Check entry-permission flag (positive permission requirement)
+		// If set, only players with this permission can enter
+		String entryPermission = toSet.queryValue(player, Flags.ENTRY_PERMISSION);
+		if (entryPermission != null && !entryPermission.isEmpty())
+		{
+			if (!bukkitPlayer.hasPermission(entryPermission))
+			{
+				// Player doesn't have the required permission, deny entry
+				sendDeniedMessage(player, bukkitPlayer, toSet, "entry-permission", entryPermission);
+				return false; // Deny entry
+			}
+		}
+
+		// Check entry-deny-permission flag (negative permission - denies entry)
+		// If set, players with this permission cannot enter (unless entry-permission allowed them above)
+		String entryDenyPermission = toSet.queryValue(player, Flags.ENTRY_DENY_PERMISSION);
+		if (entryDenyPermission != null && !entryDenyPermission.isEmpty())
+		{
+			// Only apply deny if player doesn't have entry-permission that allowed them
+			if (entryPermission == null || entryPermission.isEmpty())
+			{
+				if (bukkitPlayer.hasPermission(entryDenyPermission))
+				{
+					// Player has the deny permission and no allow permission, deny entry
+					sendDeniedMessage(player, bukkitPlayer, toSet, "entry-deny-permission", entryDenyPermission);
+					return false; // Deny entry
+				}
+			}
+		}
+
+		return true; // Allow entry
+	}
+
+	/**
+	 * Sends a message to a player when entry is denied.
+	 * Messages.sendMessageWithCooldown() from the Spigot module.
+	 */
+	private void sendDeniedMessage(LocalPlayer localPlayer, Player player, ApplicableRegionSet toSet, String flagType, String permission)
+	{
+		if (player == null || !player.isOnline())
+		{
+			return;
+		}
+
+		final String messageKey;
+		if ("entry-permission".equals(flagType))
+		{
+			messageKey = "entry-permission-denied";
+		}
+		else // entry-deny-permission
+		{
+			messageKey = "entry-deny-permission-denied";
+		}
+
+		// Send message with cooldown using FoliaLib scheduler (runs on entity thread)
+		WorldGuardUtils.getScheduler().runAtEntity(player, task -> {
+			if (player.isOnline())
+			{
+				sendMessageWithCooldown(player, messageKey, new String[]{"permission", permission});
+			}
+		});
+	}
+
+	/**
+	 * Sends a message to a player with cooldown using reflection (WG module can't depend on Spigot module).
+	 * Uses Messages.sendMessageWithCooldown() from Spigot module.
+	 */
+	private void sendMessageWithCooldown(Player player, String key, String... replacements)
+	{
+		try
+		{
+			// Use reflection to call Messages.sendMessageWithCooldown() from Spigot module
+			Class<?> messagesClass = Class.forName("dev.tins.worldguardextraflagsplus.Messages");
+			java.lang.reflect.Method sendMessageMethod = messagesClass.getMethod("sendMessageWithCooldown",
+				org.bukkit.entity.Player.class, String.class, String[].class);
+			sendMessageMethod.invoke(null, player, key, replacements);
+		}
+		catch (Exception e)
+		{
+			// Fallback to sending message directly without cooldown if reflection fails
+			String message;
+			
+			if ("entry-permission-denied".equals(key))
+			{
+				message = org.bukkit.ChatColor.RED + "You don't have permission to enter this area.";
+			}
+			else if ("entry-deny-permission-denied".equals(key))
+			{
+				message = org.bukkit.ChatColor.RED + "You are not allowed to enter this area.";
+			}
+			else
+			{
+				message = org.bukkit.ChatColor.RED + "Entry denied.";
+			}
+
+			if (player.isOnline())
+			{
+				player.sendMessage(message);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add two new flags, entry-permission and entry-deny-permission, that gate region entry based on a Bukkit permission node rather than XP level, complementing the existing entry-min-level / entry-max-level flags.

Tested on Purpur 26.2 with LuckPerms.

## Usage:
```
/rg flag <region> entry-permission myPlugin.myPermission.1
/rg flag <region> entry-deny-permission myPlugin.myPermission.2
```
- ```entry-permission```: only players holding the given permission may enter
- ```entry-deny-permission```: players holding the given permission are denied entry
If a player matches both, entry-permission takes priority

Closes #22

## Changes:

- Flags.java: register ENTRY_PERMISSION / ENTRY_DENY_PERMISSION using a new PermissionStateFlag type
- PermissionStateFlag.java: new flag type that validates permission strings (alphanumeric, dots, hyphens, underscores, wildcards) on parse
- EntryPermissionFlagHandler.java: new handler on onCrossBoundary — checks bypass and online status first, then entry-permission, then entry-deny-permission (skipped if entry-permission already allowed the player), sending a cooldown-based deny message via the existing Messages reflection bridge
- WorldGuardExtraFlagsPlusPlugin.java: register both flags and the new handler
- Config.java: add entry-permission / entry-deny-permission cases to isFlagEnabled()
- PluginConfig.java: add entryPermission / entryDenyPermission toggles to AllFlagsControl (both default true)
- PluginMessages.java: add configurable deny messages for both flags (not reusing WG's base entry-deny-message due to compatibility issues)