### PR TITLE
tweak: make default PluginMessages resemble WorldGuard counterparts

### DIFF
--- a/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/config/PluginMessages.java
+++ b/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/config/PluginMessages.java
@@ -34,9 +34,10 @@ public final class PluginMessages {
 		Use /wg reload or /wgefp reload (or /wgefplus reload or /worldguardextraflagsplus reload) to reload messages without restarting the server.
 		
 		Placeholders:
-		  {required} - The required level/threshold value
-		  {current}  - The player's current level/value
-		  {item}     - The item name that was blocked
+		  {required}   - The required level/threshold value
+		  {current}    - The player's current level/value
+		  {item}       - The item name that was blocked
+		  {permission} - The permission that was required/denied
 		
 		Message Cooldown:
 		  Prevents message spam by adding a cooldown between messages sent to the same player.
@@ -48,41 +49,47 @@ public final class PluginMessages {
 		"Message cooldown in seconds",
 		"Prevents message spam by adding a cooldown between messages sent to the same player",
 		"Set to 0 to disable cooldown (messages will always be sent)",
-		"Default: 3 seconds"
+		"Default: 2 seconds"
 	})
-	private int sendMessageCooldown = 3;
+	private int sendMessageCooldown = 2;
 	
 	@Comment("Entry level flags messages")
-	private String entryMinLevelDenied = "&cYour level (&7{current}&c) is low to enter this area. &7Min: &8{required}";
+	private String entryMinLevelDenied = "&c&lHey! &r&7Sorry, but your level (&8{current}&7/&8{required}&7) is too low to enter this area.";
 	
 	@Comment("Entry level flags messages")
-	private String entryMaxLevelDenied = "&cYour level (&7{current}&c) is so high to enter this area. &7Max: &8{required}";
+	private String entryMaxLevelDenied = "&c&lHey! &r&7Sorry, but your level (&8{current}&7/&8{required}&7) is too high to enter this area.";
 	
+	@Comment("Entry permission flags messages")
+	private String entryPermissionDenied = "&c&lHey! &r&7Sorry, but you do not have the required permission (&8{permission}&7) to enter this area.";
+	
+	@Comment("Entry permission flags messages")
+	private String entryDenyPermissionDenied = "&c&lHey! &r&7Sorry, but you can't enter this area with the permission (&8{permission}&7).";
+
 	@Comment("Disable completely flag message")
-	private String disableCompletelyBlocked = "&cHey! &7You can not use {item} in here!";
+	private String disableCompletelyBlocked = "&c&lHey! &r&7Sorry, but you can't use &f{item} &7here!";
 	
 	@Comment("Disable throw flag — egg, snowball, ender pearl, experience bottle (see ThrowableItemFlag)")
-	private String disableThrowBlocked = "&cHey! &7You can not throw {item} here!";
+	private String disableThrowBlocked = "&c&lHey! &r&7Sorry, but you can't throw &f{item} &7here!";
 
 	@Comment("Permit workbenches flag message")
-	private String permitWorkbenchesBlocked = "&cHey! &7You can not use {workbench} in here!";
+	private String permitWorkbenchesBlocked = "&c&lHey! &r&7Sorry, but you can't use &f{workbench}&7 here!";
 	
 	@Comment("Inventory craft flag message")
-	private String inventoryCraftBlocked = "&cHey! &7You can not craft items in your inventory here!";
+	private String inventoryCraftBlocked = "&c&lHey! &r&7Sorry, but you can't inventory craft here!";
 
 	@Comment("WorldEdit / FAWE denied by region worldedit flag")
-	private String worldeditDenied = "&cYou can not use WorldEdit here (worldedit flag).";
+	private String worldeditDenied = "&c&lHey! &r&7Sorry, but you cannot use WorldEdit here.";
 	
 	@Comment("Godmode disabled message (extra plugins and worldguard)")
-	private String godmodeDisabled = "&cHey! &7Godmode disabled in this region!";
+	private String godmodeDisabled = "&c&lHey! &r&7Sorry, but god mode is disabled in this region!";
 
 	@Comment({
 		"Message shown when player tries to interact with block they're standing on",
 		"Helps players understand why bucket interactions fail when standing on water/lava"
 	})
-	private String standingOnBlockInteraction = "&eHey! &7Move slightly off the block to interact with it!";
+	private String standingOnBlockInteraction = "&c&lHey! &r&7Sorry, but you need to move slightly off the block to interact with it!";
 
 	@Comment("Player count limit denied message")
-	private String playerCountLimitDenied = "&cThis region is full! Maximum players: {limit}";
+	private String playerCountLimitDenied = "&c&lHey! &r&7Sorry, but this region is full! Maximum players: &f{limit}";
 }
 


### PR DESCRIPTION
With this change, default PluginMessages now resemble WorldGuard seamlessly.

## Changes
- Fixed typos and idiomatic English in default flag messages
- Added ```{permission}``` to placeholder guide comment
- Changed the default message cooldown from 3 seconds to 2 seconds (matches WG better based on tests)
- Added "**Hey!** Sorry, but" to each flag to imitate WG defaults

Merge after #23 has been decided because a merge conflict may occur.