### PR TITLE
fix: log startup logo through Bukkit logger

### DIFF
--- a/.media/WorldGuardExtraFlagsPlus_Desc-MD-FORMAT.md
+++ b/.media/WorldGuardExtraFlagsPlus_Desc-MD-FORMAT.md
@@ -1,6 +1,6 @@
 # WorldGuard ExtraFlags Plus (WGEFP)
 
-**Release 4.4.5**
+**Release 4.4.6**
 
 An advanced WorldGuard extension that adds **45+ extra region flags** for full control of player behavior, teleportation, and region rules — featuring Folia support, item blocking (Mace, Firework, Wind Charge, Totem, Goat Horn, Spears), throwable-only blocking (`disable-throw` for egg, snowball, pearl, XP bottle), optional PacketEvents/ProtocolLib packet hooks for full `disable-completely` coverage, and fully customizable messages.
 
@@ -48,7 +48,7 @@ All managed with standard WorldGuard flag commands.
 
 | Minecraft       | WorldGuard | ExtraFlagsPlus | Support   |
 | --------------- | ---------- | -------------- | --------- |
-| 1.21 – 26.2+ | 7.0.15+    | 4.4.5+         | ✅ Active |
+| 1.21 – 26.2+ | 7.0.15+    | 4.4.6+         | ✅ Active |
 | 1.7 – 1.19     | Older      | ❌ No support  |           |
 
 The jar declares `api-version: 1.21` in `plugin.yml` so Paper **1.21.x** servers (and forks such as Canvas) load it.
@@ -68,7 +68,7 @@ All plugin messages live in `plugins/WorldGuard/messages-wgefp.yml`.
 
 ## Support & Community
 
-- 📜 **Changelog:** [CHANGELOG.md](https://github.com/tinsware/WorldGuardExtraFlagsPlus/blob/master/CHANGELOG.md) — release **4.4.5**
+- 📜 **Changelog:** [CHANGELOG.md](https://github.com/tinsware/WorldGuardExtraFlagsPlus/blob/master/CHANGELOG.md) — release **4.4.6**
 - 💬 **Discord:** [Join our Discord server](https://tinsware.github.io/discord)
 
 ⭐ If you like this project, give it a star on [GitHub](https://github.com/tinsware/WorldGuardExtraFlagsPlus)

--- a/.media/WorldGuardExtraFlagsPlus_InlineFixed_BBCode.bbcode
+++ b/.media/WorldGuardExtraFlagsPlus_InlineFixed_BBCode.bbcode
@@ -1,6 +1,6 @@
 [CENTER][B][SIZE=6]WorldGuard ExtraFlags Plus (WGEFP)[/SIZE][/B][/CENTER]
 
-[B]Release 4.4.5[/B]
+[B]Release 4.4.6[/B]
 
 An advanced WorldGuard extension that adds [B]45+ extra region flags[/B] for full control of player behavior, teleportation, and region rules — featuring Folia support, item blocking (Mace, Firework, Wind Charge, Totem, Goat Horn, Spears), throwable-only blocking ([I]disable-throw[/I] for egg, snowball, pearl, XP bottle), optional PacketEvents/ProtocolLib packet hooks for full [I]disable-completely[/I] coverage, and fully customizable messages.
 
@@ -48,7 +48,7 @@ All managed with standard WorldGuard flag commands.
 [B][SIZE=5]Version Compatibility[/SIZE][/B]
 [TABLE]
 [TR][TH]Minecraft[/TH][TH]WorldGuard[/TH][TH]ExtraFlagsPlus[/TH][TH]Support[/TH][/TR]
-[TR][TD]1.21 – 26.2+[/TD][TD]7.0.15+[/TD][TD]4.4.5+[/TD][TD][COLOR=#00FF00]✅ Active[/COLOR][/TD][/TR]
+[TR][TD]1.21 – 26.2+[/TD][TD]7.0.15+[/TD][TD]4.4.6+[/TD][TD][COLOR=#00FF00]✅ Active[/COLOR][/TD][/TR]
 [TR][TD]1.7 – 1.19[/TD][TD]Older[/TD][TD]-[/TD][TD][COLOR=#FF0000]❌ No support[/COLOR][/TD][/TR]
 [/TABLE]
 
@@ -71,7 +71,7 @@ All plugin messages live in [I]plugins/WorldGuard/messages-wgefp.yml[/I].
 
 [B][SIZE=5]Support & Community[/SIZE][/B]
 [LIST]
-[*]📜 [B]Changelog:[/B] [URL=https://github.com/tinsware/WorldGuardExtraFlagsPlus/blob/master/CHANGELOG.md]CHANGELOG.md[/URL] — release [B]4.4.5[/B]
+[*]📜 [B]Changelog:[/B] [URL=https://github.com/tinsware/WorldGuardExtraFlagsPlus/blob/master/CHANGELOG.md]CHANGELOG.md[/URL] — release [B]4.4.6[/B]
 [*]💬 [B]Discord:[/B] [URL=https://tinsware.github.io/discord]Join our Discord server[/URL]
 [/LIST]
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 WorldGuard ExtraFlags Plus (WGEFP) is a plugin extension for [WorldGuard](https://github.com/EngineHub/WorldGuard) that adds **45+ extra region flags** — item & throwable blocking, entry control, chat formatting, and region command automation.
 
-**Release 4.4.5**
+**Release 4.4.6**
 
 ## ⚠️ Warning DO NOT USE BOTH PLUGINS TOGETHER!
 
@@ -108,5 +108,5 @@ Install [PlaceholderAPI](https://www.spigotmc.org/resources/placeholderapi.6245/
 
 ## Support & Community
 
-- 📜 **Changelog:** [CHANGELOG.md](CHANGELOG.md) (release **4.4.5**)
+- 📜 **Changelog:** [CHANGELOG.md](CHANGELOG.md) (release **4.4.6**)
 - 💬 **Discord:** [Join our Discord server](https://tinsware.github.io/discord)

--- a/Spigot/pom.xml
+++ b/Spigot/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>dev.tins</groupId>
 		<artifactId>worldguardextraflagsplus</artifactId>
-		<version>4.4.5</version>
+		<version>4.4.6</version>
 	</parent>
 
 	<groupId>dev.tins.worldguardextraflagsplus</groupId>

--- a/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/WorldGuardExtraFlagsPlusPlugin.java
+++ b/Spigot/src/main/java/dev/tins/worldguardextraflagsplus/WorldGuardExtraFlagsPlusPlugin.java
@@ -1051,7 +1051,7 @@ public class WorldGuardExtraFlagsPlusPlugin extends JavaPlugin
 	}
 
 	/**
-	 * Startup logo — direct console output, no plugin prefix (ANSI colors embedded in each line).
+	 * Startup logo — ANSI colors are embedded in each line.
 	 * Replace logo lines below as needed.
 	 */
 	private void displayPluginLogo()
@@ -1068,10 +1068,10 @@ public class WorldGuardExtraFlagsPlusPlugin extends JavaPlugin
 		logoLine("");
 	}
 
-	/** Logo line — no {@code [PluginName]} logger prefix. */
-	private static void logoLine(String message)
+	/** Logs one startup logo line through Bukkit's plugin logger. */
+	private void logoLine(String message)
 	{
-		System.out.println(message);
+		this.getLogger().info(message);
 	}
 }
 

--- a/Spigot/src/main/resources/plugin.yml
+++ b/Spigot/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ description: |
   WorldGuard ExtraFlags Plus (WGEFP) — 44+ extra region flags for WorldGuard: item & throwable blocking, entry control (XP / permission / player count), chat formatting, and region command automation. Folia supported.
   GitHub: https://github.com/tinsware/WorldGuardExtraFlagsPlus
 main: dev.tins.worldguardextraflagsplus.WorldGuardExtraFlagsPlusPlugin
-version: 4.4.5
+version: 4.4.6
 api-version: '1.21'
 folia-supported: true
 depend: [ WorldGuard ]

--- a/WG/pom.xml
+++ b/WG/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>dev.tins</groupId>
 		<artifactId>worldguardextraflagsplus</artifactId>
-		<version>4.4.5</version>
+		<version>4.4.6</version>
 	</parent>
 
 	<groupId>dev.tins.worldguardextraflagsplus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
    <groupId>dev.tins</groupId>
    <artifactId>worldguardextraflagsplus</artifactId>
    <name>WorldGuardExtraFlagsPlus</name>
-   <version>4.4.5</version>
+   <version>4.4.6</version>
    
    <packaging>pom</packaging>
 


### PR DESCRIPTION
## Summary

- Replace direct `System.out.println` startup-logo output with the plugin logger (`JavaPlugin#getLogger().info(...)`).
- Remove the Bukkit/Paper nag warning about `System.out/err.print` usage.
- Preserve the logo text and ANSI colour sequences; Bukkit's logger prefix is now expected.
  - https://github.com/tinsware/WorldGuardExtraFlagsPlus/pull/29/changes#diff-4443531fcd9d525a600043a8f42e6a9fd6fe6a37c6f04a68ae6e0c194df264e8
- Bump the project, module, plugin descriptor, README, and publication-description versions from `4.4.5` to `4.4.6`.

## Validation

- `mvn clean verify` completed successfully for the parent, `wg`, and `Spigot` modules.
- Confirmed no tracked `System.out/err.print*` call or `4.4.5` version reference remains.
- Confirmed the generated plugin JAR embeds `plugin.yml` with version `4.4.6`.